### PR TITLE
Fixing some paths when preparing Android setup from Windows

### DIFF
--- a/android/setup.sh
+++ b/android/setup.sh
@@ -17,8 +17,14 @@ mkdir --parents res/drawable-ldpi res/drawable-mdpi res/drawable-hdpi res/drawab
 # ______________________________________________________________________________
 #
 case $(uname) in
-	"Windows_NT") SDK_OS="win";;
-	"Linux") SDK_OS="linux";;
+	"Windows_NT") 
+		SDK_OS="win"
+		NDK_OS="windows"
+		;;
+	"Linux")
+		SDK_OS="linux"
+		NDK_OS="linux"
+		;;
 esac
 
 # Download SDK

--- a/android/setup.sh
+++ b/android/setup.sh
@@ -41,7 +41,7 @@ cd $SDK/cmdline-tools/bin
 
 # Download NDK
 cd $NDK/..
-[[ -e android-ndk.zip ]] || wget https://dl.google.com/android/repository/android-ndk-r23b-$SDK_OS.zip -O android-ndk.zip
+[[ -e android-ndk.zip ]] || wget https://dl.google.com/android/repository/android-ndk-r23b-$NDK_OS.zip -O android-ndk.zip
 unzip android-ndk
 
 # ______________________________________________________________________________

--- a/config.sh
+++ b/config.sh
@@ -66,8 +66,13 @@ SDK=$(pwd)/android/sdk/$(uname)
 NDK=$(pwd)/android/ndk/$(uname)/android-ndk-r23b
 BUILD=$(pwd)/android/build
 
+case $(uname) in
+	"Windows_NT") TOOLCHAIN_OS="windows-x86_64";;
+	"Linux") TOOLCHAIN_OS="linux-x86_64";;
+esac
+
 BUILD_TOOLS_VERSION=29.0.3
 BUILD_TOOLS=$SDK/build-tools/$BUILD_TOOLS_VERSION
-TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
+TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/$TOOLCHAIN_OS
 NATIVE_APP_GLUE=$NDK/sources/android/native_app_glue
 AR=$TOOLCHAIN/bin/llvm-ar


### PR DESCRIPTION
Fixes regarding minor issues I found when running `TARGET=Android ./setup.sh` on windows.

After these changes, the android set-up seems to work. I'll continue looking at the build stage.