### PR TITLE
Fix cross compilation issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ case "$TARGET" in
 		CC="$ARCH-w64-mingw32-gcc"
 		EXT=".exe"
 		PLATFORM="PLATFORM_DESKTOP"
-		TARGET_FLAGS="-lopengl32 -lgdi32 -lwinmm -Wl,--subsystem,windows"
+		TARGET_FLAGS="-lopengl32 -lgdi32 -lwinmm -static -Wl,--subsystem,windows"
 		;;
 
 	"Linux")


### PR DESCRIPTION
When running cross-compiled games on Arch Linux the following error would pop up:
0100:err:module:import_dll Library libwinpthread-1.dll (which is needed by L"Z:\\work\\game.exe") not found

The fix to this was adding the `-static` flag to the compilation flags
for Windows_NT target. This WAS NOT tested on native Windows platforms
or other Linux distributions.