### PR TITLE
Add ArchLinux to dependency manager

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,9 @@ elif command -v dnf > /dev/null; then
 	echo "Installing dependencies"
 	sudo dnf install alsa-lib-devel mesa-libGL-devel libX11-devel \
 	libXrandr-devel libXi-devel libXcursor-devel libXinerama-devel
+ elif command -v pacman > /dev/null; then
+ 	echo "Installing dependencies"
+  	sudo pacman -Syu alsa-lib mesa libx11 libxrandr libxi libxcursor libxinerama
 fi
 
 # ______________________________________________________________________________


### PR DESCRIPTION
Adds Arch Linux as a potential operating system to install the dependencies with its package manager (pacman).